### PR TITLE
Fixed deprecated code warning in unity 5.6. 

### DIFF
--- a/HighlightHelper.cs
+++ b/HighlightHelper.cs
@@ -85,11 +85,12 @@ public class HighlightHelper {
 
         float circleSize = bounds.size.magnitude*0.5f;
 
-        Handles.CircleCap(0, bounds.center,
-            sceneGameObject.transform.rotation, circleSize - onePixelOffset);
-        Handles.CircleCap(0, bounds.center,
-            sceneGameObject.transform.rotation, circleSize + onePixelOffset);
-        Handles.CircleCap(0, bounds.center, sceneGameObject.transform.rotation, circleSize);
+        Handles.CircleHandleCap(0, bounds.center,
+            sceneGameObject.transform.rotation, circleSize - onePixelOffset, EventType.Repaint);
+        Handles.CircleHandleCap(0, bounds.center,
+            sceneGameObject.transform.rotation, circleSize + onePixelOffset, EventType.Repaint);
+        Handles.CircleHandleCap(0, bounds.center, 
+            sceneGameObject.transform.rotation, circleSize, EventType.Repaint);
     }
 
     private static int _hoveredInstance;


### PR DESCRIPTION
Thanks for HighlightHelper.

in unity 5.6
```
warning CS0618: `UnityEditor.Handles.CircleCap(int, UnityEngine.Vector3, UnityEngine.Quaternion, float)' is obsolete: `Use CircleHandleCap instead'
```

'CircleHandleCap' is released from unity5.5.0. maybe not working for unity 5.4.0 below.

https://docs.unity3d.com/540/Documentation/ScriptReference/Handles.html
https://docs.unity3d.com/550/Documentation/ScriptReference/Handles.html
https://docs.unity3d.com/560/Documentation/ScriptReference/Handles.html


